### PR TITLE
Bug fix for deploys with no shared_paths

### DIFF
--- a/lib/vlad/core.rb
+++ b/lib/vlad/core.rb
@@ -79,7 +79,7 @@ namespace :vlad do
     ops = shared_paths.map do |sp, rp|
       "ln -s #{shared_path}/#{sp} #{latest_release}/#{rp}"
     end
-    run ops.join(' && ')
+    run ops.join(' && ') unless ops.length == 0
   end
 
   desc "Invoke a single command on every remote server. This is useful for


### PR DESCRIPTION
I'm using vlad to deploy a static site and therefore do not need any of the shared_paths to be symlinked.  Instead of overriding the symlink task, I figured the better approach would be to set shared_paths to {} in my deployment recipe so that both setup and update do not attempt to operate on these paths.

Unfortunately, update_symlinks does not check to ensure that there are operations to run so the deploy ends up hanging.

This commit fixes the issue by checking for operations before running them.

Justin
