### PR TITLE
Allow use with rake 0.9.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ Hoe.spec 'vlad' do
   developer 'Eric Hodel',       'drbrain@segment7.net'
   developer 'Wilson Bilkovich', 'wilson@supremetyrant.com'
 
-  extra_deps << ['rake',  '~> 0.8.0']
+  extra_deps << ['rake',  '>= 0.8.0', '< 0.10.0']
   extra_deps << ['rake-remote_task',  '~> 2.0']
   extra_deps << ['open4', '~> 0.9.0']
 


### PR DESCRIPTION
This expands the version dependency on rake from ~> 0.8.0 (i.e. >= 0.8.0, < 0.9.0) to >= 0.8.0, < 0.10.0, the minimal expansion necessary to allow vlad to be used with the newly released rake 0.9.x.
