### PR TITLE
Set a sane :skip_scm default

### DIFF
--- a/lib/vlad.rb
+++ b/lib/vlad.rb
@@ -61,6 +61,8 @@ module Vlad
       next if recipe.nil? or flavor == :config
       require "vlad/#{recipe}"
     end
+    
+    set :skip_scm, false
 
     Kernel.load recipes[:config]
     Kernel.load "config/deploy_#{ENV['to']}.rb" if ENV['to']


### PR DESCRIPTION
:skip_scm is used in lib/vlad/core.rb but an assumption is made that :skip_scm is set somewhere which it won't be for most people upgrading from the previous version. 

This new feature is also not documented anywhere. In an effort to get this to Just Work(TM) one should most likely add a sane default somewhere.
