### PR TITLE
Load deploy_#{ENV['to']} from the same path as the config recipe

### DIFF
--- a/lib/vlad.rb
+++ b/lib/vlad.rb
@@ -65,7 +65,7 @@ module Vlad
     set :skip_scm, false
 
     Kernel.load recipes[:config]
-    Kernel.load "config/deploy_#{ENV['to']}.rb" if ENV['to']
+    Kernel.load "#{File.dirname(recipes[:config])}/deploy_#{ENV['to']}.rb" if ENV['to']
   end
 end
 


### PR DESCRIPTION
When a config path is given other than 'config/' and the 'to' variable is passed, Vlad will attempt to load "config/deploy_#{ENV['to']}".

Rakefile

```
require 'vlad'
Vlad.load(:config => 'other/deploy.rb')
```

Output

```
% rake vlad:debug to=somewhere
Loaded other/deploy.rb
rake abort!
cannot load such file -- config/deploy_somewhere.rb
```

This commit will load deploy_somewhere.rb from the same path as the config recipe.

```
% rake vlad:debug to=somewhere
Loaded other/deploy.rb
Loaded other/deploy_somewhere.rb
```
