### PR TITLE
Trust umask for release file trees, fix #25

### DIFF
--- a/lib/vlad/core.rb
+++ b/lib/vlad/core.rb
@@ -68,7 +68,6 @@ namespace :vlad do
         commands << "#{source.checkout revision, scm_path}"
       end
       commands << "#{source.export revision, release_path}"
-      commands << "chmod -R g+w #{latest_release}"
       
       unless shared_paths.empty?
         commands << "rm -rf #{shared_paths.values.map { |p| File.join(latest_release, p) }.join(' ')}"


### PR DESCRIPTION
Fix for #25

Simply removed the useless forced `chmod -R g+w`

Regards,
Mathieu.
