### PR TITLE
use syck yaml engine for debug task

### DIFF
--- a/lib/vlad/core.rb
+++ b/lib/vlad/core.rb
@@ -12,10 +12,7 @@ namespace :vlad do
 
   task :debug do
     require 'yaml'
-    
-    # force syck. In ruby 1.9.3 psych is default which has no y method 
-    YAML::ENGINE.yamler = 'syck'
-    
+
     # force them into values
     Rake::RemoteTask.env.keys.each do |key|
       next if key =~ /_release|releases|sudo_password/

--- a/lib/vlad/core.rb
+++ b/lib/vlad/core.rb
@@ -12,7 +12,10 @@ namespace :vlad do
 
   task :debug do
     require 'yaml'
-
+    
+    # force syck. In ruby 1.9.3 psych is default which has no y method 
+    YAML::ENGINE.yamler = 'syck'
+    
     # force them into values
     Rake::RemoteTask.env.keys.each do |key|
       next if key =~ /_release|releases|sudo_password/

--- a/lib/vlad/core.rb
+++ b/lib/vlad/core.rb
@@ -24,9 +24,9 @@ namespace :vlad do
 
     puts "# Environment:"
     puts
-    y Rake::RemoteTask.env
+    puts Rake::RemoteTask.env.to_yaml
     puts "# Roles:"
-    y Rake::RemoteTask.roles
+    puts Rake::RemoteTask.roles.to_yaml
   end
 
   append :ancillary_dir


### PR DESCRIPTION
the :debug task does not work with ruby 1.9.3 because the y method is 
missing in the :psych yaml engine, which is the default in 1.9.3.
Setting the yaml lib back to :syck helps, but there may me a better solution for that.
Maybe awesome_print does a better job?
