### PR TITLE
Inform user about missing vlad gem in rescue block

### DIFF
--- a/doco/getting_started.txt
+++ b/doco/getting_started.txt
@@ -1,4 +1,3 @@
-
 == Quick Start for a 1-Server Solution:
 
 === Setup
@@ -39,8 +38,9 @@ refer to the {variable documentation}[rdoc-ref:doco/variables.txt].
     begin
       require 'vlad'
       Vlad.load
-    rescue LoadError
-      # do nothing
+    rescue LoadError => e
+      puts e.message
+      puts "Could not load Vlad, please install via 'gem install vlad'"
     end
 
 Vlad.load has a lot of flexibility. See the rdoc for full information.


### PR DESCRIPTION
If vlad gem is missing, the empty rescue block hides the error from the user. As users copy from the Getting Started guide this might end up in a lot of rakefiles. Alternatively the begin|rescue|end block could be removed completely to get a "cannot load such file -- vlad" message.
