### PR TITLE
Removing the revision function in favor of simply setting a variable

### DIFF
--- a/lib/vlad/subversion.rb
+++ b/lib/vlad/subversion.rb
@@ -24,13 +24,4 @@ class Vlad::Subversion
         "#{revision_or_source} #{destination}"
       end
   end
-
-  ##
-  # Returns a command that maps human-friendly revision identifier +revision+
-  # into a subversion revision specification.
-
-  def revision(revision)
-    "`#{svn_cmd} info #{repository} | grep 'Revision:' | cut -f2 -d\\ `"
-  end
 end
-

--- a/lib/vlad/subversion.rb
+++ b/lib/vlad/subversion.rb
@@ -2,6 +2,7 @@ class Vlad::Subversion
 
   set :source, Vlad::Subversion.new
   set :svn_cmd, "svn"
+  set :revision, "HEAD"
 
   ##
   # Returns the command that will check out +revision+ from the repository

--- a/test/test_vlad_subversion.rb
+++ b/test/test_vlad_subversion.rb
@@ -23,4 +23,8 @@ class TestVladSubversion < MiniTest::Unit::TestCase
     expected = "`svn info svn+ssh://repo/myproject | grep 'Revision:' | cut -f2 -d\\ `"
     assert_equal expected, cmd
   end
+
+  def test_set_defaults
+    [source, svn_cmd, revision].each { |var| assert var }
+  end
 end


### PR DESCRIPTION
See Issue #40 and Issue #41. This has been tested against a fake_vlad_deploy project using rake-remote_task 2.2.1.
