### PR TITLE
rake -T missing some vlad tasks because the "String.cleanup" returns nil.

### DIFF
--- a/lib/vlad.rb
+++ b/lib/vlad.rb
@@ -74,7 +74,7 @@ class String #:nodoc:
     if ENV['FULL'] then
       gsub(/\s+/, ' ').strip
     else
-      self[/\A.*?\./]
+      self.gsub(/(\n|\s)+/, ' ')[/\A.*?(\.|\z)/]
     end
   end
 end


### PR DESCRIPTION
Hi, I am not sure if it's a bug or it is the behavior you want. 

When listing tasks with `rake -T`, it displays only the tasks with descriptions. 
And some vlad tasks' description disappear after calling `cleanup` therefore they are not displayed by `rake -T` (but they are displayed by `rake -P` which lists every task with or without comments).

This patch modifies the Vlad-defined-method `String.cleanup`, make it replace `(\n|\s)+` with `' '` and match the first sentence ended with period or the entire string if there's no period. With this modification `rake -T` will list the `upload` and `update_symlinks` tasks which are missing before.
