### PR TITLE
Fix update_symlinks regression

### DIFF
--- a/lib/vlad/core.rb
+++ b/lib/vlad/core.rb
@@ -108,7 +108,7 @@ namespace :vlad do
     begin
       ops = []
       unless shared_paths.empty?
-        ops = shared_paths.each do |sp, rp|
+        shared_paths.each do |sp, rp|
           ops << "ln -s #{shared_path}/#{sp} #{latest_release}/#{rp}"
         end
       end


### PR DESCRIPTION
The commit 2cba94436b14e1608e05d80947be472e1408efb5 broke the `update_symlinks` task by falsely assigning the ops variable, which led to ops being a Hash.
