### PR TITLE
Extend range of compatible Rake versions to include 13.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Hoe.spec 'vlad' do
   developer 'Eric Hodel',       'drbrain@segment7.net'
   developer 'Wilson Bilkovich', 'wilson@supremetyrant.com'
 
-  dependency 'rake',             ['>= 0.8', '< 11.0']
+  dependency 'rake',             ['>= 0.8', '< 14.0']
   dependency 'rake-remote_task', '~> 2.3'
 
   multiruby_skip << "rubinius"


### PR DESCRIPTION
I want to use rake 13.x. So I bumped the compatible version, and all tests pass with rake 13.0.1.

Thank you for this gem!